### PR TITLE
buid: use Buffer.from instead of Buffer constructor

### DIFF
--- a/lib/urlsafe-base64.js
+++ b/lib/urlsafe-base64.js
@@ -56,7 +56,7 @@ exports.decode = function decode(base64) {
     .replace(/\-/g, '+') // Convert '-' to '+'
     .replace(/\_/g, '/'); // Convert '_' to '/'
 
-  return new Buffer(base64, 'base64');
+  return Buffer.from(base64).toString('base64');
 
 };
 


### PR DESCRIPTION
> DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Closes #14