### PR TITLE
throw an error if encode input is not a buffer

### DIFF
--- a/lib/urlsafe-base64.js
+++ b/lib/urlsafe-base64.js
@@ -29,6 +29,7 @@ exports.version = '1.0.0';
  */
 
 exports.encode = function encode(buffer) {
+  if (!Buffer.isBuffer(buffer)) throw new TypeError('The input should be a buffer.')
 
   return buffer.toString('base64')
     .replace(/\+/g, '-') // Convert '+' to '-'


### PR DESCRIPTION
This prevents the user to wrongly provide a string, where the method `.toString()` doesn't accept any parameter.

```
> '+'.toString('base64')
'+'
> '+'.toString('hex')
'+'
```

so it's failing silently right now 😬